### PR TITLE
Use vfork and exec

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -3,5 +3,6 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
   conf.gem mgem: 'mruby-process'
   conf.gem '../mruby-clean-spawn'
+  conf.enable_debug
   conf.enable_test
 end

--- a/src/mrb_cleanspawn.c
+++ b/src/mrb_cleanspawn.c
@@ -111,11 +111,12 @@ static mrb_value mrb__test_fd_leak(mrb_state *mrb, mrb_value self)
 
 void mrb_mruby_clean_spawn_gem_init(mrb_state *mrb)
 {
-  struct RClass *kern, *cleanspawn;
+  struct RClass *kern;
   kern = mrb->kernel_module;
   mrb_define_method(mrb, kern, "clean_spawn", mrb_do_cleanspawn, MRB_ARGS_ANY());
 
 #ifdef MRB_DEBUG
+  struct RClass *cleanspawn;
   cleanspawn = mrb_define_module(mrb, "CleanSpawn");
   mrb_define_module_function(mrb, cleanspawn, "_test_fd_leak", mrb__test_fd_leak, MRB_ARGS_NONE());
 #endif


### PR DESCRIPTION
This patch makes valgrind memtest pass.

## Before:

```console
$ valgrind ./mruby/bin/mruby -e "10.times {clean_spawn '/bin/bash', '-c', 'pwd'}"             
==7189== Memcheck, a memory error detector
==7189== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==7189== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==7189== Command: ./mruby/bin/mruby -e 10.times\ {clean_spawn\ '/bin/bash',\ '-c',\ 'pwd'}
==7189== 
trace:
        [0] -e:1
        [2] -e:1:in call
-e:1:posix_spawn_file_actions_addclose (RuntimeError)
==7189== 
==7189== HEAP SUMMARY:
==7189==     in use at exit: 33,104 bytes in 3 blocks
==7189==   total heap usage: 2,717 allocs, 2,714 frees, 481,969 bytes allocated
==7189== 
==7189== LEAK SUMMARY:
==7189==    definitely lost: 33,104 bytes in 3 blocks
==7189==    indirectly lost: 0 bytes in 0 blocks
==7189==      possibly lost: 0 bytes in 0 blocks
==7189==    still reachable: 0 bytes in 0 blocks
==7189==         suppressed: 0 bytes in 0 blocks
==7189== Rerun with --leak-check=full to see details of leaked memory
==7189== 
==7189== For counts of detected and suppressed errors, rerun with: -v
==7189== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## After:

```console
$ valgrind ./mruby/bin/mruby -e "10.times {clean_spawn '/bin/bash', '-c', 'pwd'}"             
==21962== Memcheck, a memory error detector
==21962== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==21962== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==21962== Command: ./mruby/bin/mruby -e 10.times\ {clean_spawn\ '/bin/bash',\ '-c',\ 'pwd'}
==21962== 
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
/Users/udzura/.ghq/github.com/udzura/mruby-clean-spawn
==21962== 
==21962== HEAP SUMMARY:
==21962==     in use at exit: 0 bytes in 0 blocks
==21962==   total heap usage: 4,586 allocs, 4,586 frees, 497,635 bytes allocated
==21962== 
==21962== All heap blocks were freed -- no leaks are possible
==21962== 
==21962== For counts of detected and suppressed errors, rerun with: -v
==21962== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
