### PR TITLE
Hadling nice with signals

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -2,7 +2,9 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
   conf.gem mgem: 'mruby-process'
-  conf.gem mgem: 'mruby-signal'
+  if ENV['TEST_SIGNAL']
+    conf.gem mgem: 'mruby-signal'
+  end
   conf.gem '../mruby-clean-spawn'
   conf.enable_debug
   conf.enable_test


### PR DESCRIPTION
The `system(3)` function ignores SIGINT/SIGTERM and blocks SIGCHLD.

Also, makes a SIGCHLD handler to behaves like default as [mruby-process does](https://github.com/iij/mruby-process/blob/master/src/process.c#L224-L226).