### PR TITLE
Making new process group

### DIFF
--- a/src/mrb_cleanspawn.c
+++ b/src/mrb_cleanspawn.c
@@ -107,6 +107,8 @@ static mrb_value mrb_do_cleanspawn(mrb_state *mrb, mrb_value self)
     (void)sigaction(SIGCHLD, &chld, (struct sigaction *)NULL);
     (void)sigprocmask(SIG_SETMASK, &omask, (sigset_t *)NULL);
 
+    (void)setpgid(0, 0);
+
     d = opendir("/proc/self/fd");
     if (!d) {
       mrb_sys_fail(mrb, "opendir: /proc/self/fd");


### PR DESCRIPTION
Calling `clean_spawn "/bin/sh", "-c", "sleep 60 &"` from mirb ...

## Before:

```console
vagrant@localhost:~$ grep pgid /proc/28706/status                                                                                                                     
NSpgid: 28704
vagrant@localhost:~$ pgrep mirb
28704
```

## After:

```console
vagrant@localhost:~$ grep pgid /proc/$(pgrep sleep)/status                                                                                                            
NSpgid: 28762
vagrant@localhost:~$ pgrep mirb                                                                                                                                       
28761
```