### PR TITLE
To assign new cgroup root

### DIFF
--- a/mrblib/mrb_cleanspawn.rb
+++ b/mrblib/mrb_cleanspawn.rb
@@ -1,2 +1,9 @@
 module CleanSpawn
+  def self.cgroup_root_path
+    @cgroup_root_path || nil
+  end
+
+  def self.cgroup_root_path=(newpath)
+    @cgroup_root_path = newpath
+  end
 end

--- a/src/mrb_cleanspawn.c
+++ b/src/mrb_cleanspawn.c
@@ -160,6 +160,8 @@ static mrb_value mrb_do_cleanspawn(mrb_state *mrb, mrb_value self)
         mrb_sys_fail(mrb, "write pid to task");
         _exit(2);
       }
+
+      mrb_free(mrb, path);
     }
 
     execve(program, argv, environ);

--- a/src/mrb_cleanspawn.c
+++ b/src/mrb_cleanspawn.c
@@ -68,7 +68,7 @@ static mrb_value mrb_do_cleanspawn(mrb_state *mrb, mrb_value self)
 
   argv[0] = program;
   for (i = 0; i < argc; i++) {
-    argv[i + 1] = mrb_string_value_cstr(mrb, &rest[i]);
+    argv[i + 1] = mrb_str_to_cstr(mrb, rest[i]);
   }
   argv[argc + 1] = NULL;
 
@@ -161,8 +161,10 @@ static mrb_value mrb_do_cleanspawn(mrb_state *mrb, mrb_value self)
         _exit(2);
       }
       p = (int)getpid();
-      while (p = p / 10) {
+      while ((p = p / 10) > 0) {
         pidlen++;
+        if (pidlen >= PID_STR_LEN_MAX)
+          break;
       }
       snprintf(pidstr, pidlen, "%d", p);
       fwrite(pidstr, 1, pidlen, taskf);


### PR DESCRIPTION
With systemd, forked process belongs to parent's cgroup at first.

```
> CleanSpawn.cgroup_root_path = "/sys/fs/cgroup/systemd"
 => "/sys/fs/cgroup/systemd"
> clean_spawn "/bin/sh", "-c", "sleep 10"
# This process is out of parent session's cgroup
 => true
```